### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Dependencies
 
 ```
-pkg install curl ncurses-utils 
+pkg install curl ncurses-utils xz-utils
 ```
 
 ## Installation


### PR DESCRIPTION
Without xz-utils, the getnf script errors out and can't unpack the tarball.

```
Installing Hack... tar: xz: Cannot exec: Permission denied
tar: Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```